### PR TITLE
fixed light themes displaying white text I beam cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "themes": [
             {
                 "label": "Slack Theme Aubergine",
-                "uiTheme": "vs-dark",
+                "uiTheme": "vs",
                 "path": "./themes/aubergine.json"
             },
             {
@@ -39,22 +39,22 @@
             },
             {
                 "label": "Slack Theme Monument",
-                "uiTheme": "vs-dark",
+                "uiTheme": "vs",
                 "path": "./themes/monument.json"
             },
             {
                 "label": "Slack Theme Ochin",
-                "uiTheme": "vs-dark",
+                "uiTheme": "vs",
                 "path": "./themes/ochin.json"
             },
             {
                 "label": "Slack Theme Work Hard",
-                "uiTheme": "vs-dark",
+                "uiTheme": "vs",
                 "path": "./themes/work-hard.json"
             },
             {
                 "label": "Slack Theme Choco Mint",
-                "uiTheme": "vs-dark",
+                "uiTheme": "vs",
                 "path": "./themes/choco-mint.json"
             },
             {
@@ -64,12 +64,12 @@
             },
             {
                 "label": "Slack Theme Protanopia & Deuteranopia",
-                "uiTheme": "vs-dark",
+                "uiTheme": "vs",
                 "path": "./themes/protanopia-deuteranopia.json"
             },
             {
                 "label": "Slack Theme Tritanopia",
-                "uiTheme": "vs-dark",
+                "uiTheme": "vs",
                 "path": "./themes/tritanopia.json"
             },
             {

--- a/themes/aubergine.json
+++ b/themes/aubergine.json
@@ -1,6 +1,6 @@
 {  
     "name":"Slack Theme Aubergine",
-    "type":"dark",
+    "type":"light",
     "colors":{
         "foreground":"#36373B",
         "focusBorder":"#3E313C",

--- a/themes/choco-mint.json
+++ b/themes/choco-mint.json
@@ -1,6 +1,6 @@
 {  
     "name":"Slack Theme Choco Mint",
-    "type":"dark",
+    "type":"light",
     "colors":{
         "foreground":"#36373B",
         "focusBorder":"#2B231D",

--- a/themes/monument.json
+++ b/themes/monument.json
@@ -1,6 +1,6 @@
 {  
     "name":"Slack Theme Monument",
-    "type":"dark",
+    "type":"light",
     "colors":{
         "foreground":"#36373B",
         "focusBorder":"#003F42",

--- a/themes/ochin.json
+++ b/themes/ochin.json
@@ -1,6 +1,6 @@
 {  
     "name":"Slack Theme Ochin",
-    "type":"dark",
+    "type":"light",
     "colors":{
         "foreground":"#36373B",
         "focusBorder":"#161F26",

--- a/themes/protanopia-deuteranopia.json
+++ b/themes/protanopia-deuteranopia.json
@@ -1,6 +1,6 @@
 {  
     "name":"Slack Theme Protanopia & Deuteranopia",
-    "type":"dark",
+    "type":"light",
     "colors":{
         "foreground":"#36373B",
         "focusBorder":"#1D0B19",

--- a/themes/tritanopia.json
+++ b/themes/tritanopia.json
@@ -1,6 +1,6 @@
 {  
     "name":"Slack Theme Tritanopia",
-    "type":"dark",
+    "type":"light",
     "colors":{
         "foreground":"#36373B",
         "focusBorder":"#1D0B19",

--- a/themes/work-hard.json
+++ b/themes/work-hard.json
@@ -1,6 +1,6 @@
 {  
     "name":"Slack Theme Work Hard",
-    "type":"dark",
+    "type":"light",
     "colors":{
         "foreground":"#36373B",
         "focusBorder":"#272928",


### PR DESCRIPTION
Hi
I really liked these themes, but because they were set as dark themes in the project.json, vscode was displaying a white I-Beam text caret, making it difficult to keep track of my mouse.