### PR TITLE
Fix info, warning and error messages background for better readability

### DIFF
--- a/themes/aubergine-new.json
+++ b/themes/aubergine-new.json
@@ -143,7 +143,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#F6B555",
-        "debugExceptionWidget.border":"#21081F"
+        "debugExceptionWidget.border":"#21081F",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#E01E5A",
+        "editorMarkerNavigationWarning.background":"#ECB22E",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/aubergine.json
+++ b/themes/aubergine.json
@@ -143,7 +143,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#F6B555",
-        "debugExceptionWidget.border":"#261C25"
+        "debugExceptionWidget.border":"#261C25",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#F44C5E",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/choco-mint.json
+++ b/themes/choco-mint.json
@@ -135,7 +135,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#F6B555",
-        "debugExceptionWidget.border":"#2B231D"
+        "debugExceptionWidget.border":"#2B231D",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#F44C5E",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/hoth.json
+++ b/themes/hoth.json
@@ -135,7 +135,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#AED4FB",
-        "debugExceptionWidget.border":"#261C25"
+        "debugExceptionWidget.border":"#261C25",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#F44C5E",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/monument.json
+++ b/themes/monument.json
@@ -135,7 +135,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#FF9F6C",
-        "debugExceptionWidget.border":"#003F42"
+        "debugExceptionWidget.border":"#003F42",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#F44C5E",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/ochin.json
+++ b/themes/ochin.json
@@ -135,7 +135,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#AED4FB",
-        "debugExceptionWidget.border":"#161F26"
+        "debugExceptionWidget.border":"#161F26",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#F44C5E",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/protanopia-deuteranopia.json
+++ b/themes/protanopia-deuteranopia.json
@@ -143,7 +143,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#c9b9c5",
-        "debugExceptionWidget.border":"#291825"
+        "debugExceptionWidget.border":"#291825",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#87A440",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/tritanopia.json
+++ b/themes/tritanopia.json
@@ -143,7 +143,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#c9b9c5",
-          "debugExceptionWidget.border":"#291825"
+        "debugExceptionWidget.border":"#291825",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#00FAB7",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  

--- a/themes/work-hard.json
+++ b/themes/work-hard.json
@@ -135,7 +135,13 @@
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
         "debugExceptionWidget.background":"#ffb62c",
-        "debugExceptionWidget.border":"#272928"
+        "debugExceptionWidget.border":"#272928",
+        "editorMarkerNavigation.background":"#F9F9F9",
+        "editorMarkerNavigationInfo.background":"#6182b8",
+        "editorMarkerNavigationError.background":"#F44C5E",
+        "editorMarkerNavigationWarning.background":"#F6B555",
+        "peekViewTitleDescription.foreground":"#685C66",
+        "peekViewTitleLabel.foreground":"#2D3E4C"
     },
     "tokenColors":[  
        {  


### PR DESCRIPTION
There is a background colour issue with info, warning and error messages on light themes that makes them difficult to read.

Before:
![example1](https://user-images.githubusercontent.com/25001029/69015449-a0e5e780-09df-11ea-9282-06a132a1c705.png)

After:
![example2](https://user-images.githubusercontent.com/25001029/69015456-aa6f4f80-09df-11ea-82b0-70a373825ff0.png)
