### PR TITLE
[Ochin] Fix peek window color

### DIFF
--- a/themes/ochin.json
+++ b/themes/ochin.json
@@ -163,7 +163,6 @@
         "menu.separatorBackground": "#F9FAFA",
         "menu.background": "#161F26",
         "menu.foreground": "#F9FAFA",
-        "peekViewEditor.matchHighlightBorder":"#161F26",
         "textPreformat.foreground":"#161F26",
         "editorIndentGuide.background":"#F3F3F3",
         "editorIndentGuide.activeBackground":"#dbdbdb",
@@ -174,7 +173,14 @@
         "editorMarkerNavigationError.background":"#F44C5E",
         "editorMarkerNavigationWarning.background":"#F6B555",
         "peekViewTitleDescription.foreground":"#685C66",
-        "peekViewTitleLabel.foreground":"#2D3E4C"
+        "peekViewTitleLabel.foreground":"#FFF",
+        "peekViewTitle.background": "#2D3E4C",
+        "peekViewEditor.background": "#FFF",
+        "peekViewEditor.matchHighlightBorder":"#161F26",
+        "peekViewEditorGutter.background": "#161F26",
+        "peekViewResult.background": "#2D3E4C",
+        "peekViewResult.fileForeground": "#FFF",
+        "peekViewResult.lineForeground": "#DCDEDF"
     },
     "tokenColors":[  
        {  


### PR DESCRIPTION
#18 

This forces the title background to be dark with white text, and editor background to be white to be consistent with main window, plus a few other tweaks like gutter.

**Before**
![image](https://user-images.githubusercontent.com/1372575/80298283-81e24300-873f-11ea-8170-6329aaaade3f.png)

**After**
![image](https://user-images.githubusercontent.com/1372575/80294564-f6f15080-871e-11ea-8be7-8586868b2098.png)
